### PR TITLE
Remove hyphens from transaction-id

### DIFF
--- a/src/main/java/com/jibo/apptoolkit/protocol/CommandRequester.java
+++ b/src/main/java/com/jibo/apptoolkit/protocol/CommandRequester.java
@@ -9,7 +9,6 @@ import com.jibo.apptoolkit.protocol.model.Header;
 import com.jibo.apptoolkit.protocol.utils.Commons;
 import com.jibo.apptoolkit.protocol.utils.LruCache;
 import com.jibo.apptoolkit.protocol.utils.StringUtils;
-import com.jibo.apptoolkit.protocol.utils.Util;
 
 import org.json.JSONObject;
 
@@ -301,7 +300,7 @@ public class CommandRequester {
     }
 
     private String generateTransactionID() {
-        return UUID.randomUUID().toString();
+        return UUID.randomUUID().toString().replace("-", "");
     }
 
     private void removeResponseListeners() {


### PR DESCRIPTION
I've did it because I was not able to send transactions longer than 32 character. This was the response of Jibo:

com.jibo.apptoolkit.android.example D/ROMSDK_SdkConnectionMa: Receiving : {"ResponseHeader":{"RobotID":"","TransactionID":"aad24437-e8e9-401b-9ee9-37a95064840d","SessionID":null},"Response":{"ResponseCode":400,"ResponseString":"Bad Request","Value":"Error","ErrorDetail":".ClientHeader.TransactionID should NOT be longer than 32 characters"}}